### PR TITLE
LFLT-569 Add support for querying MDC data in TLP / LFLT-572 Add support for querying log thread in TLP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>leaflet-tlql-processor</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>3.0-r2305.1</version>
+        <version>3.2-r2307.3</version>
     </parent>
 
     <properties>

--- a/src/it/resources/testdata/expectation/scenario_1.json
+++ b/src/it/resources/testdata/expectation/scenario_1.json
@@ -3,7 +3,9 @@
     {
       "conditions": [
         {
-          "object": "SOURCE",
+          "objectContext": {
+            "object": "SOURCE"
+          },
           "operator": "EITHER",
           "value": null,
           "multipleValue": [
@@ -15,7 +17,9 @@
           "nextConditionOperator": "AND"
         },
         {
-          "object": "LEVEL",
+          "objectContext": {
+            "object": "LEVEL"
+          },
           "operator": "EQUALS",
           "value": "error",
           "multipleValue": null,
@@ -23,7 +27,9 @@
           "nextConditionOperator": "AND"
         },
         {
-          "object": "TIMESTAMP",
+          "objectContext": {
+            "object": "TIMESTAMP"
+          },
           "operator": "GREATER_THAN",
           "value": null,
           "multipleValue": null,
@@ -35,7 +41,9 @@
           "nextConditionOperator": "AND"
         },
         {
-          "object": "MESSAGE",
+          "objectContext": {
+            "object": "MESSAGE"
+          },
           "operator": "LIKE",
           "value": "something went wrong",
           "multipleValue": null,

--- a/src/it/resources/testdata/expectation/scenario_2.json
+++ b/src/it/resources/testdata/expectation/scenario_2.json
@@ -3,7 +3,9 @@
     {
       "conditions": [
         {
-          "object": "SOURCE",
+          "objectContext": {
+            "object": "SOURCE"
+          },
           "operator": "EQUALS",
           "value": "lcfa",
           "multipleValue": null,
@@ -16,7 +18,9 @@
     {
       "conditions": [
         {
-          "object": "LEVEL",
+          "objectContext": {
+            "object": "LEVEL"
+          },
           "operator": "EQUALS",
           "value": "error",
           "multipleValue": null,
@@ -24,7 +28,9 @@
           "nextConditionOperator": "OR"
         },
         {
-          "object": "LOGGER",
+          "objectContext": {
+            "object": "LOGGER"
+          },
           "operator": "NOT_EQUALS",
           "value": "hu.psprog.leaflet.lcfa.Something",
           "multipleValue": null,

--- a/src/it/resources/testdata/expectation/scenario_3.json
+++ b/src/it/resources/testdata/expectation/scenario_3.json
@@ -3,7 +3,9 @@
     {
       "conditions": [
         {
-          "object": "SOURCE",
+          "objectContext": {
+            "object": "SOURCE"
+          },
           "operator": "EQUALS",
           "value": "lcfa",
           "multipleValue": null,
@@ -11,7 +13,9 @@
           "nextConditionOperator": "OR"
         },
         {
-          "object": "SOURCE",
+          "objectContext": {
+            "object": "SOURCE"
+          },
           "operator": "EQUALS",
           "value": "cbfs",
           "multipleValue": null,
@@ -24,7 +28,9 @@
     {
       "conditions": [
         {
-          "object": "LEVEL",
+          "objectContext": {
+            "object": "LEVEL"
+          },
           "operator": "EQUALS",
           "value": "error",
           "multipleValue": null,
@@ -37,7 +43,9 @@
     {
       "conditions": [
         {
-          "object": "LEVEL",
+          "objectContext": {
+            "object": "LEVEL"
+          },
           "operator": "EQUALS",
           "value": "warn",
           "multipleValue": null,
@@ -45,7 +53,9 @@
           "nextConditionOperator": "OR"
         },
         {
-          "object": "LOGGER",
+          "objectContext": {
+            "object": "LOGGER"
+          },
           "operator": "EQUALS",
           "value": "hu.psprog.leaflet.lcfa.Something",
           "multipleValue": null,

--- a/src/it/resources/testdata/expectation/scenario_5.json
+++ b/src/it/resources/testdata/expectation/scenario_5.json
@@ -3,7 +3,9 @@
     {
       "conditions": [
         {
-          "object": "SOURCE",
+          "objectContext": {
+            "object": "SOURCE"
+          },
           "operator": "NONE",
           "value": null,
           "multipleValue": [
@@ -14,7 +16,9 @@
           "nextConditionOperator": "AND"
         },
         {
-          "object": "LEVEL",
+          "objectContext": {
+            "object": "LEVEL"
+          },
           "operator": "EITHER",
           "value": null,
           "multipleValue": [
@@ -26,7 +30,9 @@
           "nextConditionOperator": "AND"
         },
         {
-          "object": "TIMESTAMP",
+          "objectContext": {
+            "object": "TIMESTAMP"
+          },
           "operator": "BETWEEN",
           "value": null,
           "multipleValue": null,

--- a/src/it/resources/testdata/expectation/scenario_6.json
+++ b/src/it/resources/testdata/expectation/scenario_6.json
@@ -39,6 +39,16 @@
         },
         {
           "objectContext": {
+            "object": "THREAD"
+          },
+          "operator": "NOT_EQUALS",
+          "value": "main",
+          "multipleValue": null,
+          "timestampValue": null,
+          "nextConditionOperator": "AND"
+        },
+        {
+          "objectContext": {
             "object": "TIMESTAMP"
           },
           "operator": "BETWEEN",

--- a/src/it/resources/testdata/expectation/scenario_6.json
+++ b/src/it/resources/testdata/expectation/scenario_6.json
@@ -3,7 +3,9 @@
     {
       "conditions": [
         {
-          "object": "SOURCE",
+          "objectContext": {
+            "object": "SOURCE"
+          },
           "operator": "EQUALS",
           "value": "leaflet",
           "multipleValue": null,
@@ -11,7 +13,34 @@
           "nextConditionOperator": "AND"
         },
         {
-          "object": "TIMESTAMP",
+          "objectContext": {
+            "object": "CONTEXT",
+            "specialization": "requestID"
+          },
+          "operator": "EQUALS",
+          "value": "request1234",
+          "multipleValue": null,
+          "timestampValue": null,
+          "nextConditionOperator": "AND"
+        },
+        {
+          "objectContext": {
+            "object": "CONTEXT",
+            "specialization": "trace_id"
+          },
+          "operator": "EITHER",
+          "value": null,
+          "multipleValue": [
+            "trace-1234",
+            "trace-4567"
+          ],
+          "timestampValue": null,
+          "nextConditionOperator": "AND"
+        },
+        {
+          "objectContext": {
+            "object": "TIMESTAMP"
+          },
           "operator": "BETWEEN",
           "value": null,
           "multipleValue": null,

--- a/src/it/resources/testdata/queries/scenario_6.tlql
+++ b/src/it/resources/testdata/queries/scenario_6.tlql
@@ -1,5 +1,7 @@
 search
 with conditions
   source = "leaflet"
+  and requestID = "request1234"
+  and trace_id either ("trace-1234", 'trace-4567')
   and timestamp between ]2021-03-21 12:00:00, 2021-03-28 23:00:00[
 with limit 100

--- a/src/it/resources/testdata/queries/scenario_6.tlql
+++ b/src/it/resources/testdata/queries/scenario_6.tlql
@@ -3,5 +3,6 @@ with conditions
   source = "leaflet"
   and requestID = "request1234"
   and trace_id either ("trace-1234", 'trace-4567')
+  and thread != "main"
   and timestamp between ]2021-03-21 12:00:00, 2021-03-28 23:00:00[
 with limit 100

--- a/src/main/java/hu/psprog/leaflet/tlql/grammar/DSLMapping.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/grammar/DSLMapping.java
@@ -23,6 +23,7 @@ public interface DSLMapping {
             QueryLanguageToken.OBJECT_MESSAGE, DSLObject.MESSAGE,
             QueryLanguageToken.OBJECT_TIMESTAMP, DSLObject.TIMESTAMP,
             QueryLanguageToken.OBJECT_LOGGER, DSLObject.LOGGER,
+            QueryLanguageToken.OBJECT_THREAD, DSLObject.THREAD,
             QueryLanguageToken.OBJECT_CONTEXT, DSLObject.CONTEXT
     );
 

--- a/src/main/java/hu/psprog/leaflet/tlql/grammar/DSLMapping.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/grammar/DSLMapping.java
@@ -22,7 +22,8 @@ public interface DSLMapping {
             QueryLanguageToken.OBJECT_LEVEL, DSLObject.LEVEL,
             QueryLanguageToken.OBJECT_MESSAGE, DSLObject.MESSAGE,
             QueryLanguageToken.OBJECT_TIMESTAMP, DSLObject.TIMESTAMP,
-            QueryLanguageToken.OBJECT_LOGGER, DSLObject.LOGGER
+            QueryLanguageToken.OBJECT_LOGGER, DSLObject.LOGGER,
+            QueryLanguageToken.OBJECT_CONTEXT, DSLObject.CONTEXT
     );
 
     /**

--- a/src/main/java/hu/psprog/leaflet/tlql/grammar/GrammarParserContext.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/grammar/GrammarParserContext.java
@@ -4,6 +4,7 @@ import hu.psprog.leaflet.tlql.exception.DSLParserException;
 import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLConditionGroup;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLOrderDirection;
 import hu.psprog.leaflet.tlql.ir.DSLQueryModel;
 
@@ -250,6 +251,25 @@ public class GrammarParserContext {
         discardToken();
 
         return value;
+    }
+
+    /**
+     * Extracts the current token as object (after verification), then advances the context.
+     * Also extracts the contextual information for the given object (if any).
+     *
+     * @return extracted object and its contextual specification, wrapped as {@link DSLObjectContext}
+     */
+    public DSLObjectContext extractObjectAndAdvance() {
+
+        assertExpectedToken(QueryLanguageToken.TokenGroup.OBJECT);
+        DSLObject object = DSLMapping.TOKEN_TO_OBJECT_MAP.get(lookAheadFirst.getToken());
+        String specialization = object.isSpecialized()
+                ? lookAheadFirst.getValue()
+                : null;
+
+        discardToken();
+
+        return new DSLObjectContext(object, specialization);
     }
 
     private <T> T assertNonNullValue(T value) {

--- a/src/main/java/hu/psprog/leaflet/tlql/grammar/QueryLanguageToken.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/grammar/QueryLanguageToken.java
@@ -29,6 +29,7 @@ public enum QueryLanguageToken {
     OBJECT_MESSAGE("message", 1, TokenGroup.OBJECT, 0),
     OBJECT_TIMESTAMP("timestamp", 1, TokenGroup.OBJECT, 0),
     OBJECT_LOGGER("logger", 1, TokenGroup.OBJECT, 0),
+    OBJECT_THREAD("thread", 1, TokenGroup.OBJECT, 0),
     OBJECT_CONTEXT("([a-zA-Z-_]+)", 10, TokenGroup.OBJECT, 0),
 
     OPERATOR_EQUAL("=", 1, TokenGroup.OPERATOR, 0),

--- a/src/main/java/hu/psprog/leaflet/tlql/grammar/QueryLanguageToken.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/grammar/QueryLanguageToken.java
@@ -29,6 +29,7 @@ public enum QueryLanguageToken {
     OBJECT_MESSAGE("message", 1, TokenGroup.OBJECT, 0),
     OBJECT_TIMESTAMP("timestamp", 1, TokenGroup.OBJECT, 0),
     OBJECT_LOGGER("logger", 1, TokenGroup.OBJECT, 0),
+    OBJECT_CONTEXT("([a-zA-Z-_]+)", 10, TokenGroup.OBJECT, 0),
 
     OPERATOR_EQUAL("=", 1, TokenGroup.OPERATOR, 0),
     OPERATOR_NOT_EQUAL("!=", 1, TokenGroup.OPERATOR, 0),

--- a/src/main/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/MultiMatchConditionSectionParser.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/MultiMatchConditionSectionParser.java
@@ -33,7 +33,7 @@ public class MultiMatchConditionSectionParser extends AbstractConditionSectionPa
 
         DSLCondition currentCondition = context.createDSLCondition();
 
-        currentCondition.setObject(context.extractValueAndAdvance(DSLMapping.TOKEN_TO_OBJECT_MAP::get));
+        currentCondition.setObjectContext(context.extractObjectAndAdvance());
         currentCondition.setOperator(context.extractValueAndAdvance(DSLMapping.TOKEN_TO_OPERATOR_MAP::get));
         currentCondition.setMultipleValue(extractParameters(context));
     }

--- a/src/main/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/SimpleConditionSectionParser.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/SimpleConditionSectionParser.java
@@ -30,7 +30,7 @@ public class SimpleConditionSectionParser extends AbstractConditionSectionParser
 
         DSLCondition currentCondition = context.createDSLCondition();
 
-        currentCondition.setObject(context.extractValueAndAdvance(DSLMapping.TOKEN_TO_OBJECT_MAP::get));
+        currentCondition.setObjectContext(context.extractObjectAndAdvance());
         currentCondition.setOperator(context.extractValueAndAdvance(DSLMapping.TOKEN_TO_OPERATOR_MAP::get));
         currentCondition.setValue(context.readToken(QueryLanguageToken.TokenGroup.LITERAL).getValue());
         context.discardToken();

--- a/src/main/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/TimestampConditionSectionParser.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/TimestampConditionSectionParser.java
@@ -47,7 +47,7 @@ public class TimestampConditionSectionParser extends AbstractConditionSectionPar
 
         DSLCondition currentCondition = context.createDSLCondition();
 
-        currentCondition.setObject(context.extractValueAndAdvance(DSLMapping.TOKEN_TO_OBJECT_MAP::get));
+        currentCondition.setObjectContext(context.extractObjectAndAdvance());
         currentCondition.setOperator(context.extractValueAndAdvance(DSLMapping.TOKEN_TO_OPERATOR_MAP::get));
 
         if (currentCondition.getOperator() == DSLOperator.BETWEEN) {

--- a/src/main/java/hu/psprog/leaflet/tlql/ir/DSLCondition.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/ir/DSLCondition.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Data
 public class DSLCondition {
 
-    private DSLObject object;
+    private DSLObjectContext objectContext;
     private DSLOperator operator;
     private String value;
     private List<String> multipleValue;

--- a/src/main/java/hu/psprog/leaflet/tlql/ir/DSLObject.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/ir/DSLObject.java
@@ -15,6 +15,7 @@ public enum DSLObject {
     TIMESTAMP(false),
     MESSAGE(false),
     LOGGER(false),
+    THREAD(false),
     CONTEXT(true);
 
     private final boolean specialized;

--- a/src/main/java/hu/psprog/leaflet/tlql/ir/DSLObject.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/ir/DSLObject.java
@@ -1,15 +1,25 @@
 package hu.psprog.leaflet.tlql.ir;
 
+import lombok.Getter;
+
 /**
  * Possible condition or ordering objects in IR.
  *
  * @author Peter Smith
  */
+@Getter
 public enum DSLObject {
 
-    SOURCE,
-    LEVEL,
-    TIMESTAMP,
-    MESSAGE,
-    LOGGER
+    SOURCE(false),
+    LEVEL(false),
+    TIMESTAMP(false),
+    MESSAGE(false),
+    LOGGER(false),
+    CONTEXT(true);
+
+    private final boolean specialized;
+
+    DSLObject(boolean specialized) {
+        this.specialized = specialized;
+    }
 }

--- a/src/main/java/hu/psprog/leaflet/tlql/ir/DSLObjectContext.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/ir/DSLObjectContext.java
@@ -1,0 +1,19 @@
+package hu.psprog.leaflet.tlql.ir;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Helper class for holding contextual information for a {@link DSLObject}.
+ *
+ * @author Peter Smith
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DSLObjectContext {
+
+    private DSLObject object;
+    private String specialization;
+}

--- a/src/test/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/MultiMatchConditionSectionParserTest.java
+++ b/src/test/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/MultiMatchConditionSectionParserTest.java
@@ -5,6 +5,7 @@ import hu.psprog.leaflet.tlql.grammar.GrammarParserContext;
 import hu.psprog.leaflet.tlql.grammar.strategy.QuerySection;
 import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLOperator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,7 @@ class MultiMatchConditionSectionParserTest extends AbstractSectionParserBaseTest
         GrammarParserContext grammarParserContext =
                 prepareGrammarParserContext("source either ('lcfa') with limit");
         DSLCondition expectedDSLCondition = new DSLCondition();
-        expectedDSLCondition.setObject(DSLObject.SOURCE);
+        expectedDSLCondition.setObjectContext(new DSLObjectContext(DSLObject.SOURCE, null));
         expectedDSLCondition.setOperator(DSLOperator.EITHER);
         expectedDSLCondition.setMultipleValue(Collections.singletonList("lcfa"));
 
@@ -82,7 +83,7 @@ class MultiMatchConditionSectionParserTest extends AbstractSectionParserBaseTest
         GrammarParserContext grammarParserContext =
                 prepareGrammarParserContext("level none ('info', 'warning', 'error') with limit");
         DSLCondition expectedDSLCondition = new DSLCondition();
-        expectedDSLCondition.setObject(DSLObject.LEVEL);
+        expectedDSLCondition.setObjectContext(new DSLObjectContext(DSLObject.LEVEL, null));
         expectedDSLCondition.setOperator(DSLOperator.NONE);
         expectedDSLCondition.setMultipleValue(Arrays.asList("info", "warning", "error"));
 

--- a/src/test/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/SimpleConditionSectionParserTest.java
+++ b/src/test/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/SimpleConditionSectionParserTest.java
@@ -5,6 +5,7 @@ import hu.psprog.leaflet.tlql.grammar.GrammarParserContext;
 import hu.psprog.leaflet.tlql.grammar.strategy.QuerySection;
 import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLOperator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -103,7 +104,7 @@ class SimpleConditionSectionParserTest extends AbstractSectionParserBaseTest {
     private static DSLCondition prepareDSLCondition(DSLObject object, DSLOperator operator, String value) {
 
         DSLCondition dslCondition = new DSLCondition();
-        dslCondition.setObject(object);
+        dslCondition.setObjectContext(new DSLObjectContext(object, null));
         dslCondition.setOperator(operator);
         dslCondition.setValue(value);
 

--- a/src/test/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/TimestampConditionSectionParserTest.java
+++ b/src/test/java/hu/psprog/leaflet/tlql/grammar/strategy/impl/TimestampConditionSectionParserTest.java
@@ -5,6 +5,7 @@ import hu.psprog.leaflet.tlql.grammar.GrammarParserContext;
 import hu.psprog.leaflet.tlql.grammar.strategy.QuerySection;
 import hu.psprog.leaflet.tlql.ir.DSLCondition;
 import hu.psprog.leaflet.tlql.ir.DSLObject;
+import hu.psprog.leaflet.tlql.ir.DSLObjectContext;
 import hu.psprog.leaflet.tlql.ir.DSLOperator;
 import hu.psprog.leaflet.tlql.ir.DSLTimestampValue;
 import org.junit.jupiter.api.Assertions;
@@ -154,7 +155,7 @@ class TimestampConditionSectionParserTest extends AbstractSectionParserBaseTest 
     private static DSLCondition prepareDSLCondition(DSLOperator operator, LocalDateTime leftDateTime) {
 
         DSLCondition dslCondition = new DSLCondition();
-        dslCondition.setObject(DSLObject.TIMESTAMP);
+        dslCondition.setObjectContext(new DSLObjectContext(DSLObject.TIMESTAMP, null));
         dslCondition.setOperator(operator);
         dslCondition.setTimestampValue(new DSLTimestampValue(DSLTimestampValue.IntervalType.NONE, leftDateTime, null));
 
@@ -165,7 +166,7 @@ class TimestampConditionSectionParserTest extends AbstractSectionParserBaseTest 
                                                     LocalDateTime leftDateTime, LocalDateTime rightDateTime) {
 
         DSLCondition dslCondition = new DSLCondition();
-        dslCondition.setObject(DSLObject.TIMESTAMP);
+        dslCondition.setObjectContext(new DSLObjectContext(DSLObject.TIMESTAMP, null));
         dslCondition.setOperator(DSLOperator.BETWEEN);
         dslCondition.setTimestampValue(new DSLTimestampValue(intervalType, leftDateTime, rightDateTime));
 


### PR DESCRIPTION
LFLT-569 Add support for querying MDC data in TLP
 - Implemented support for context keywords
 - Aligned tests
 - Changed stack base BOM version to 3.2-r2307.3
 - Bumped library version to 1.2.0
 
LFLT-572 Add support for querying log thread in TLP
 - Implemented support for thread keyword
 - Aligned tests