### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   jira: circleci/jira@2.2.0
-  jq: circleci/jq@3.0.2
 
 executors:
   java:

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>leaflet-tlql-processor</artifactId>
-    <version>1.3.1</version>
+    <version>1.4.0</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>5.0-r2505.1</version>
+        <version>6.0-r2604.1</version>
     </parent>
 
     <properties>
@@ -31,12 +31,8 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -60,11 +56,23 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <proc>full</proc>
                 </configuration>
             </plugin>
             <plugin>
@@ -86,7 +94,7 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
-                    <argLine>${argLine.surefire}</argLine>
+                    <argLine>${argLine.surefire} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                     <excludes>
                         <exclude>**/*IT.java</exclude>
                     </excludes>
@@ -110,7 +118,7 @@
                         </goals>
                         <configuration>
                             <!--suppress UnresolvedMavenProperty -->
-                            <argLine>${argLine.failsafe}</argLine>
+                            <argLine>${argLine.failsafe} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/java/hu/psprog/leaflet/tlql/it/config/DSLTimestampValueDeserializer.java
+++ b/src/it/java/hu/psprog/leaflet/tlql/it/config/DSLTimestampValueDeserializer.java
@@ -1,13 +1,12 @@
 package hu.psprog.leaflet.tlql.it.config;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import hu.psprog.leaflet.tlql.ir.DSLTimestampValue;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 
 /**
@@ -22,19 +21,19 @@ public class DSLTimestampValueDeserializer extends StdDeserializer<DSLTimestampV
     }
 
     @Override
-    public DSLTimestampValue deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
+    public DSLTimestampValue deserialize(JsonParser parser, DeserializationContext ctxt) {
 
-        ObjectCodec objectCodec = parser.getCodec();
+        ObjectReadContext objectCodec = parser.objectReadContext();
         JsonNode node = objectCodec.readTree(parser);
 
-        DSLTimestampValue.IntervalType intervalType = DSLTimestampValue.IntervalType.valueOf(node.get("intervalType").asText());
-        LocalDateTime leftOfSimpleDateTime = LocalDateTime.parse(node.get("leftOrSimple").asText());
+        DSLTimestampValue.IntervalType intervalType = DSLTimestampValue.IntervalType.valueOf(node.get("intervalType").asString());
+        LocalDateTime leftOfSimpleDateTime = LocalDateTime.parse(node.get("leftOrSimple").asString());
 
         DSLTimestampValue timestampValue;
         if (intervalType == DSLTimestampValue.IntervalType.NONE) {
             timestampValue = new DSLTimestampValue(leftOfSimpleDateTime);
         } else {
-            LocalDateTime rightDateTime = LocalDateTime.parse(node.get("right").asText());
+            LocalDateTime rightDateTime = LocalDateTime.parse(node.get("right").asString());
             timestampValue = new DSLTimestampValue(intervalType, leftOfSimpleDateTime, rightDateTime);
         }
 

--- a/src/it/java/hu/psprog/leaflet/tlql/it/config/ITContextConfig.java
+++ b/src/it/java/hu/psprog/leaflet/tlql/it/config/ITContextConfig.java
@@ -1,10 +1,8 @@
 package hu.psprog.leaflet.tlql.it.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Additional configuration for integration test context.
@@ -15,12 +13,7 @@ import org.springframework.context.annotation.Configuration;
 public class ITContextConfig {
 
     @Bean
-    public ObjectMapper objectMapper() {
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-        return objectMapper;
+    public JsonMapper JsonMapper() {
+        return new JsonMapper();
     }
 }

--- a/src/it/java/hu/psprog/leaflet/tlql/it/config/TLQLIntegrationTestsArgumentProvider.java
+++ b/src/it/java/hu/psprog/leaflet/tlql/it/config/TLQLIntegrationTestsArgumentProvider.java
@@ -1,14 +1,15 @@
 package hu.psprog.leaflet.tlql.it.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import hu.psprog.leaflet.tlql.ir.DSLQueryModel;
 import hu.psprog.leaflet.tlql.ir.DSLTimestampValue;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.springframework.core.io.ClassPathResource;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,7 +31,7 @@ import java.util.stream.Stream;
 public class TLQLIntegrationTestsArgumentProvider implements ArgumentsProvider {
 
     private static final ClassPathResource SCENARIO_QUERY_FILES_PATH = new ClassPathResource("testdata/queries");
-    private final ObjectMapper objectMapper;
+    private final JsonMapper jsonMapper;
 
     TLQLIntegrationTestsArgumentProvider() {
 
@@ -38,13 +39,14 @@ public class TLQLIntegrationTestsArgumentProvider implements ArgumentsProvider {
         dslTimestampDeserializationModule.addDeserializer(DSLTimestampValue.class,
                 new DSLTimestampValueDeserializer(DSLTimestampValue.class));
 
-        this.objectMapper = new ObjectMapper();
-        this.objectMapper.registerModule(dslTimestampDeserializationModule);
-        this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        this.jsonMapper = JsonMapper.builder()
+                .addModule(dslTimestampDeserializationModule)
+                .build();
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+    @NonNull
+    public Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters, @NonNull ExtensionContext extensionContext) throws Exception {
 
         return findScenarioQueryFiles()
                 .map(this::prepareArgumentsForScenario);
@@ -54,7 +56,7 @@ public class TLQLIntegrationTestsArgumentProvider implements ArgumentsProvider {
         try {
 
             String query = Files.readString(path);
-            DSLQueryModel expectedQueryModel = objectMapper.readValue(getExpectationFile(path), DSLQueryModel.class);
+            DSLQueryModel expectedQueryModel = jsonMapper.readValue(getExpectationFile(path), DSLQueryModel.class);
 
             return Arguments.of(query, expectedQueryModel);
         } catch (IOException e) {

--- a/src/it/java/hu/psprog/leaflet/tlql/it/suites/TLQLProcessingIT.java
+++ b/src/it/java/hu/psprog/leaflet/tlql/it/suites/TLQLProcessingIT.java
@@ -1,7 +1,5 @@
 package hu.psprog.leaflet.tlql.it.suites;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import hu.psprog.leaflet.tlql.config.TLQLProcessorConfig;
 import hu.psprog.leaflet.tlql.ir.DSLQueryModel;
 import hu.psprog.leaflet.tlql.it.config.ITContextConfig;
@@ -15,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,7 +35,7 @@ public class TLQLProcessingIT {
     private TLQLProcessorService tlqlProcessorService;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
 
     @Value("${it.show-generated-query-model:false}")
     private boolean showGeneratedQueryModel;
@@ -55,12 +54,8 @@ public class TLQLProcessingIT {
 
     private void logGeneratedQueryModel(DSLQueryModel result) {
         if (showGeneratedQueryModel) {
-            try {
-                String resultAsJson = objectMapper.writeValueAsString(result);
-                LOGGER.info("Generated query model: {}", resultAsJson);
-            } catch (JsonProcessingException e) {
-                LOGGER.error("Failed to log generated query model", e);
-            }
+            String resultAsJson = jsonMapper.writeValueAsString(result);
+            LOGGER.info("Generated query model: {}", resultAsJson);
         }
     }
 }

--- a/src/main/java/hu/psprog/leaflet/tlql/ir/DSLConditionGroup.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/ir/DSLConditionGroup.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Data
 public class DSLConditionGroup {
 
-    private final List<DSLCondition> conditions = new LinkedList<>();
+    private List<DSLCondition> conditions = new LinkedList<>();
     private DSLLogicalOperator nextConditionGroupOperator;
 
 }

--- a/src/main/java/hu/psprog/leaflet/tlql/ir/DSLQueryModel.java
+++ b/src/main/java/hu/psprog/leaflet/tlql/ir/DSLQueryModel.java
@@ -15,8 +15,8 @@ import java.util.Map;
 @Data
 public class DSLQueryModel {
 
-    private final List<DSLConditionGroup> conditionGroups = new LinkedList<>();
-    private final Map<DSLObject, DSLOrderDirection> ordering = new LinkedHashMap<>();
+    private List<DSLConditionGroup> conditionGroups = new LinkedList<>();
+    private Map<DSLObject, DSLOrderDirection> ordering = new LinkedHashMap<>();
     private int offset;
     private int limit;
 

--- a/src/test/java/hu/psprog/leaflet/tlql/processor/engine/impl/RegexBasedQueryLanguageTokenizerTest.java
+++ b/src/test/java/hu/psprog/leaflet/tlql/processor/engine/impl/RegexBasedQueryLanguageTokenizerTest.java
@@ -2,12 +2,14 @@ package hu.psprog.leaflet.tlql.processor.engine.impl;
 
 import hu.psprog.leaflet.tlql.grammar.ParsedToken;
 import hu.psprog.leaflet.tlql.grammar.QueryLanguageToken;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -59,7 +61,8 @@ class RegexBasedQueryLanguageTokenizerTest {
         private int tokenIndex = 0;
 
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+        @NonNull
+        public Stream<? extends Arguments> provideArguments(@NonNull ParameterDeclarations parameters, @NonNull ExtensionContext extensionContext) {
 
             Arguments[] argumentsArray = {
 


### PR DESCRIPTION
 - Switched to stack base BOM v6.0-r2604.1
 - Aligned Jackson imports and configuration for integration tests
 - Fixed DSL models due to Jackson handling "final" fields differently now
 - POM fixes (annotation processing and Mockito warnings)
 - Bumped library version to 1.4.0